### PR TITLE
Post-pipeline v7: dual trigger + inputs.pipeline_run_id

### DIFF
--- a/.github/workflows/fuzz_report.yml
+++ b/.github/workflows/fuzz_report.yml
@@ -2,8 +2,13 @@ name: Fuzzing Report (post-pipeline)
 
 on:
   workflow_run:
-    workflows: ["Fuzzing Pipeline"]
+    workflows: ["Fuzzing Pipeline"]   # ajusta si tu pipeline se llama diferente
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pipeline_run_id:
+        description: "Actions run_id del pipeline a analizar"
+        required: true
 
 jobs:
   meta:
@@ -13,21 +18,24 @@ jobs:
     permissions:
       contents: read
       actions: write
+    env:
+      PIPE_RID: ${{ github.event.workflow_run.id || inputs.pipeline_run_id }}
     steps:
-      - name: Crear meta/reporte
+      - name: Create meta report
         run: |
+          set -euo pipefail
           mkdir -p out/meta
           {
             echo "Post-pipeline meta"
-            echo "From pipeline run: ${{ github.event.workflow_run.html_url }}"
-            echo "Pipeline RID: ${{ github.event.workflow_run.id }}"
-            echo "This run_id (post): ${{ github.run_id }}"
-          } | tee out/meta/report.txt
+            echo "From pipeline run: https://github.com/${{ github.repository }}/actions/runs/${{ env.PIPE_RID }}"
+            echo "Pipeline RID: ${{ env.PIPE_RID }}"
+            echo "This post RID: ${{ github.run_id }}"
+          } > out/meta/report.txt
           ls -l out/meta
-      - name: Subir artifact meta (garantizado)
+      - name: Upload meta artifact
         uses: actions/upload-artifact@v4
         with:
-          name: post-meta-${{ github.event.workflow_run.id }}
+          name: post-meta-${{ env.PIPE_RID }}
           path: out/meta
           if-no-files-found: error
           retention-days: 7
@@ -41,6 +49,8 @@ jobs:
       contents: read
       actions: write
       issues: write
+    env:
+      PIPE_RID: ${{ github.event.workflow_run.id || inputs.pipeline_run_id }}
 
     strategy:
       fail-fast: false
@@ -48,88 +58,76 @@ jobs:
         target: [png_parser, xxd]
 
     steps:
-      - name: Preparar carpetas
+      - name: Prepare dirs
         run: |
           set -euo pipefail
           T="${{ matrix.target }}"
           mkdir -p "dl/$T" "out/$T"
 
-      - name: Intento 1: descargar artifact "crashes-${{ matrix.target }}"
+      - name: Download crashes artifact
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ env.PIPE_RID }}
           name: crashes-${{ matrix.target }}
           path: dl/${{ matrix.target }}/crashes
           if-no-files-found: ignore
 
-      - name: Intento 2: descargar artifacts "findings-${{ matrix.target }}-*"
+      - name: Download findings artifacts
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ env.PIPE_RID }}
           pattern: findings-${{ matrix.target }}-*
           path: dl/${{ matrix.target }}/findings
           merge-multiple: true
           if-no-files-found: ignore
 
-      - name: Descomprimir y contar crashes
+      - name: Unpack and count
         id: count
         run: |
           set -euo pipefail
           T="${{ matrix.target }}"
-          echo "== Contenido descargado (dl/$T) =="
+          echo "== dl/$T =="
           ls -R "dl/$T" || true
-
           TAR=$(find "dl/$T" -type f -name '*.tar.gz' | head -n1 || true)
           COUNT=0
           if [ -n "${TAR:-}" ]; then
-            echo "Usando TAR: $TAR"
             tar -xzf "$TAR" -C "out/$T"
             C1=$(ls "out/$T"/default/crashes/id:* 2>/dev/null | wc -l || true)
             C2=$(ls "out/$T"/default/crashes/id_* 2>/dev/null | wc -l || true)
             COUNT=$(( C1 + C2 ))
-          else
-            echo "No se encontró .tar.gz; generando reporte con Crashes: 0"
           fi
-
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           {
             echo "Target: $T"
             echo "Crashes: $COUNT"
-            echo "From run: ${{ github.event.workflow_run.html_url }}"
+            echo "From run: https://github.com/${{ github.repository }}/actions/runs/${{ env.PIPE_RID }}"
           } > "out/$T/report.txt"
-
-          echo "== Contenido para subir (out/$T) =="
+          echo "== out/$T =="
           ls -l "out/$T" || true
 
-      - name: Abrir Issue si hay crashes
+      - name: Open issue if crashes
         if: steps.count.outputs.count != '0'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        # Nota: github-script usa Node; no necesita 'actions' especiales para abrir Issues
           script: |
-            const { execSync } = require('child_process');
             const T = "${{ matrix.target }}";
-            let files = '';
-            try {
-              files = execSync(`ls -1 out/${T}/default/crashes/id:* out/${T}/default/crashes/id_* 2>/dev/null || true`).toString();
-            } catch (e) {}
-            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.event.workflow_run.id }}`;
-            const body = `Pipeline run: ${url}\nTarget: ${T}\nCrashes: ${{ steps.count.outputs.count }}\n\nInputs:\n\`\`\`\n${files}\n\`\`\`\n`;
-            const res = await github.rest.issues.create({
+            const rid = process.env.PIPE_RID;
+            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${rid}`;
+            const body = `Pipeline run: ${url}\nTarget: ${T}\nCrashes: ${{ steps.count.outputs.count }}`;
+            await github.rest.issues.create({
               owner: context.repo.owner, repo: context.repo.repo,
-              title: `AFL++ crash – ${T} (post-pipeline) – run #${{ github.event.workflow_run.run_number }}`,
+              title: `AFL++ crash – ${T} (post) – run ${rid}`,
               body
             });
-            core.notice(`Issue: ${res.data.html_url}`);
 
-      - name: Subir reporte como artifact (siempre)
+      - name: Upload target report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: report-${{ matrix.target }}-${{ github.event.workflow_run.id }}
+          name: report-${{ matrix.target }}-${{ env.PIPE_RID }}
           path: out/${{ matrix.target }}
           if-no-files-found: warn
           retention-days: 7


### PR DESCRIPTION
Permite ejecutar el reporte por workflow_run y manualmente con run_id del pipeline.