### PR TITLE
Post-pipeline: incluir target 'crasher' (matrix)

### DIFF
--- a/.github/workflows/fuzz_report.yml
+++ b/.github/workflows/fuzz_report.yml
@@ -2,7 +2,7 @@ name: Fuzzing Report (post-pipeline)
 
 on:
   workflow_run:
-    workflows: ["Fuzzing Pipeline"]   # ajusta si tu pipeline se llama diferente
+    workflows: ["Fuzzing Pipeline"]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [png_parser, xxd]
+        target: [png_parser, xxd, crasher]   # <-- añadimos crasher
 
     steps:
       - name: Prepare dirs


### PR DESCRIPTION
El post-procesado ahora descarga y reporta también el job 'crasher'.