### PR TITLE
CI: dedupe crasher + artifact overwrite

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -221,6 +221,7 @@ jobs:
           path: upload/findings-crasher-${{ github.run_id }}.tar.gz
           if-no-files-found: error
           retention-days: 7
+          overwrite: true
 
   crasher:
     name: fuzz (crasher)

--- a/.github/workflows/fuzz_crasher_test.yml
+++ b/.github/workflows/fuzz_crasher_test.yml
@@ -105,3 +105,4 @@ jobs:
           path: upload/findings-crasher-${{ github.run_id }}.tar.gz
           if-no-files-found: error
           retention-days: 7
+          overwrite: true


### PR DESCRIPTION
Remove duplicated matrix entry and enable overwrite on upload-artifact to prevent 409 conflicts.